### PR TITLE
Accept any jwt claims

### DIFF
--- a/aiohttp_boilerplate/auth/__init__.py
+++ b/aiohttp_boilerplate/auth/__init__.py
@@ -7,7 +7,7 @@ import jwt
 from aiohttp_boilerplate.config import config
 from aiohttp_boilerplate.views.exceptions import JSONHTTPError
 
-CLAIM_FIELDS = ['user_id', 'email', 'is_superuser', 'is_staff']
+# CLAIM_FIELDS = ['user_id', 'email', 'is_superuser', 'is_staff']
 
 
 async def validate_token(token: str) -> Mapping:
@@ -32,9 +32,7 @@ async def validate_token(token: str) -> Mapping:
 
             claims = {}
             for k, v in encode_token(_token).items():
-                for f in CLAIM_FIELDS:
-                    if k.endswith(f):
-                        claims[f] = v
+                claims[k] = v
 
             return claims
 


### PR DESCRIPTION
@darland why do we have claims restrictions at all? fusionauth has different field naming ... so we need a way to modify claims variable but I don't understand why we cannot just copy all data from identity provider?