### PR TITLE
Add DB_MAX_INACTIVE_CONNECTION_LIFETIME option

### DIFF
--- a/aiohttp_boilerplate/config/__init__.py
+++ b/aiohttp_boilerplate/config/__init__.py
@@ -24,7 +24,8 @@ config = {
         'port': env.int('DB_PORT'),
         'min_size': env.int('DB_MIN_CONNECTIONS', 2),
         'max_size': env.int('DB_MAX_CONNECTIONS'),
-        'statement_cache_size': env.int('DB_STATEMENT_CACHE_SIZE', 0)
+        'statement_cache_size': env.int('DB_STATEMENT_CACHE_SIZE', 0),
+        'max_inactive_connection_lifetime': env.int('DB_MAX_INACTIVE_CONNECTION_LIFETIME', 300)
         # ToDo
         # Add hostname to the db
         # ToDo


### PR DESCRIPTION
@vladyslav2 обнаружил что у нас когда сайт какое то время не используется, то при открытии он чуть медленее загружаеться (но разница заметная, около 2-3 секунд). А потом снова начинает работать быстрее.

Оказываеться iohttp закрывает соединение с базой если оно не используеться больше 300 секунд.

И при запросе на бек, он открывает соединение заново, что занимает какое то время.

Нашел опцию что бы это отключить. Проверил и это помогает, предлагаю добавить как опцию для оптимизации.

Я пока не уверен и хочу проверить:
- [ ] Не будет ли postgres закрывать долго висящие соединения
- [ ] Будет ли pool их сам переоткрывать, что бы поддерживать MIN_CONN_COUNT

Но в идеале нам бы было что бы у нас всегда было открыто минимально заданное кол-во соединений что бы мы не тратили время на их открытие (а это может быть заметно когда сайтом ещё не сильно активно пользуються а 300 секунд по дефолту это слишком мало)