### PR TITLE
Return CORS-safe JSON for unhandled errors

### DIFF
--- a/aiohttp_boilerplate/middleware/defaults.py
+++ b/aiohttp_boilerplate/middleware/defaults.py
@@ -1,4 +1,9 @@
-from aiohttp import web, hdrs
+import logging
+
+from aiohttp import hdrs, web
+
+
+logger = logging.getLogger(__name__)
 
 
 def setup_cors_headers(headers, allow):
@@ -20,13 +25,18 @@ async def cross_origin_rules(request, handler):
     if origin.count(domain) > 0:
         allow = origin
 
-    # response = await handler(request)
     try:
         response = await handler(request)
-    except Exception as err:
-        if hasattr(err, 'headers'):
-            setup_cors_headers(err.headers, allow)
-        raise err
+    except web.HTTPException as err:
+        setup_cors_headers(err.headers, allow)
+        raise
+    except Exception:
+        request_logger = getattr(request, 'log', logger)
+        request_logger.exception('Unhandled exception while processing request')
+        response = web.json_response(
+            {'__error__': ['HTTP Internal Server Error']},
+            status=web.HTTPInternalServerError.status_code,
+        )
 
     setup_cors_headers(response.headers, allow)
     return response

--- a/tests/middleware/test_defaults.py
+++ b/tests/middleware/test_defaults.py
@@ -1,0 +1,69 @@
+import asyncio
+import json
+from types import SimpleNamespace
+
+import pytest
+from aiohttp import web
+
+from aiohttp_boilerplate.middleware.defaults import cross_origin_rules
+
+
+ORIGIN = 'https://app.example.com'
+
+
+def make_request():
+    return SimpleNamespace(
+        app=SimpleNamespace(conf={'domain': 'example.com'}),
+        headers={'origin': ORIGIN},
+    )
+
+
+def run_middleware(handler):
+    return asyncio.run(cross_origin_rules(make_request(), handler))
+
+
+def assert_cors_headers(headers):
+    assert headers['Access-Control-Allow-Origin'] == ORIGIN
+    assert headers['Access-Control-Allow-Credentials'] == 'true'
+    assert 'GET' in headers['Access-Control-Allow-Methods']
+    assert 'Content-Type' in headers['Access-Control-Allow-Headers']
+
+
+def test_adds_cors_headers_to_success_response():
+    async def handler(request):
+        return web.json_response({'data': 'ok'})
+
+    response = run_middleware(handler)
+
+    assert response.status == 200
+    assert json.loads(response.text) == {'data': 'ok'}
+    assert_cors_headers(response.headers)
+
+
+def test_preserves_http_exception_and_adds_cors_headers():
+    async def handler(request):
+        raise web.HTTPForbidden(text='forbidden')
+
+    with pytest.raises(web.HTTPForbidden) as raised:
+        run_middleware(handler)
+
+    assert raised.value.status == 403
+    assert raised.value.text == 'forbidden'
+    assert_cors_headers(raised.value.headers)
+
+
+def test_returns_sanitized_cors_json_for_unhandled_exception(caplog):
+    async def handler(request):
+        raise RuntimeError('sensitive database details')
+
+    with caplog.at_level('ERROR'):
+        response = run_middleware(handler)
+
+    assert response.status == 500
+    assert response.content_type == 'application/json'
+    assert json.loads(response.text) == {
+        '__error__': ['HTTP Internal Server Error'],
+    }
+    assert 'sensitive database details' not in response.text
+    assert 'Unhandled exception while processing request' in caplog.text
+    assert_cors_headers(response.headers)


### PR DESCRIPTION
## What changed

- preserve aiohttp HTTP exceptions while adding CORS headers
- convert unexpected exceptions into a sanitized JSON 500 response
- log the original traceback server-side
- add focused middleware regression tests

## Why

Unhandled Python exceptions were converted by aiohttp after the CORS middleware unwound, causing browsers to mask the underlying HTTP 500 as a CORS network error.

## Validation

- `pytest -q tests/middleware/test_defaults.py` (3 passed)
- Ruff on changed files
- compileall on changed Python files
- full legacy suite: 4 passed, 3 unrelated existing logging snapshot failures